### PR TITLE
Use ipv4 addresses by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ metabase_group: metabase
 
 metabase_app_dir: /opt/metabase
 metabase_jarfile: "{{ metabase_app_dir }}/metabase.jar"
-metabase_jvm_args: ''
+metabase_jvm_args: "-Djava.net.preferIPv4Stack=True"
 
 metabase_log_dir: /var/log/metabase
 metabase_log_file: "{{ metabase_log_dir }}/metabase.log"


### PR DESCRIPTION
It turns out some versions of Java bind to ipv6 addresses by default, which can break with all kinds of things including proxying. :see_no_evil: 

This sets the default to ipv4.