### PR TITLE
Use `metabase_host` var when doing api calls

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,7 +2,7 @@
 
 - name: ensure metabase has started (this can take a while...)
   uri:
-    url: "http://localhost:{{ metabase_port }}/api/session/properties"
+    url: "http://{{ metabase_host }}:{{ metabase_port }}/api/session/properties"
     status_code: 200
   register: metabase_api_session
   until: metabase_api_session is not failed
@@ -11,7 +11,7 @@
 
 - name: submit initial configuration
   uri:
-    url: "http://localhost:{{ metabase_port }}/api/setup"
+    url: "http://{{ metabase_host }}:{{ metabase_port }}/api/setup"
     method: POST
     body:
       token: "{{ metabase_api_session.json.setup_token }}"


### PR DESCRIPTION
I case when `metabase_host` is different than localhost, api calls fail