### PR TITLE
Support newer versions of metabase

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-metabase_version: v0.33.4
+metabase_version: v0.37.0.2
 metabase_upgrade_cleanup: true
 
 metabase_user: metabase

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -14,7 +14,7 @@
     url: "http://localhost:{{ metabase_port }}/api/setup"
     method: POST
     body:
-      token: "{{ metabase_api_session.json.setup_token }}"
+      token: "{{ metabase_api_session.json['setup-token'] }}"
       user:
         first_name: "{{ metabase_admin.first_name }}"
         last_name: "{{ metabase_admin.last_name }}"
@@ -29,7 +29,7 @@
       Accept: "application/json"
       Content-Type: "application/json"
   register: metabase_api_setup
-  when: metabase_api_session.json.setup_token
+  when: metabase_api_session.json["setup-token"]
 
 - name: create initial databases
   include_tasks: add_database.yml
@@ -38,4 +38,4 @@
   loop: "{{ metabase_databases }}"
   loop_control:
     loop_var: database_item
-  when: metabase_api_session.json.setup_token
+  when: metabase_api_session.json["setup-token"]


### PR DESCRIPTION
While trying out your role with v0.37.0.2, I noticed a bug in `tasks/configure.yml` that would cause an error. 

The response from `http://localhost:{{ metabase_port }}/api/session/properties` would response with the setup token under the key `setup-token` (with a dash) and not with an underscore.

This caused the configuration to fail because the code could not look up the value in the dictionary. (tested on Ansible 2.9.* and python 3.8.* on Ubuntu)

I hope this is useful to you - feel free to ask me to change something or test something to help you merge this.